### PR TITLE
Floating point tests + CMake support for code coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.0)
 project (dnp3hammer VERSION 1.0.0)
 
 # other options off-by-default that you can enable
-option(WERROR "Set all warnings to errors" OFF)
+option(COVERAGE "Builds the libraries with coverage info for gcov" OFF)
 
 # PkgConfig
 FIND_PACKAGE(PkgConfig) # tell cmake to require pkg-config
@@ -13,10 +13,15 @@ set(LIB_TYPE STATIC)
 set(CMAKE_C_FLAGS "-Wall -std=c99 -D_POSIX_C_SOURCE=2")
 set(CMAKE_CXX_FLAGS "-Wall -std=c++11")
 
+if(COVERAGE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+endif()
+
 # different release and debug flags
 set(CMAKE_C_FLAGS_RELEASE "-O3")
-set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
-  
+set(CMAKE_C_FLAGS_DEBUG "-g -O0")
+
 # include paths for all the local libraries
 include_directories(include)
 

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -383,6 +383,23 @@ static void test_req_select(void)
                                      "PARAM_ERROR on [3] (fir,fin) SELECT");
 }
 
+
+static void test_req_select_float(void)
+{
+    // 0x0000A03F is a little endian representation of 1.25 in IEEE-754 float
+    check_parse(dnp3_p_app_request,  "\xC0\x03\x29\x03\x17\x01\x02\x00\x00\xA0\x3F\x00", 12,
+                "[0] (fir,fin) SELECT {g41v3 qc=17 #2:1.2}");
+    check_parse(dnp3_p_app_response, "\xC0\x81\x00\x00\x29\x03\x17\x01\x02\x00\x00\xA0\x3F\x00", 14,
+                "[0] (fir,fin) RESPONSE {g41v3 qc=17 #2:1.2}");
+
+    // 0x000000000000F43F is a little endian representation of 1.25 in IEEE-754 double
+    check_parse(dnp3_p_app_request,  "\xC0\x03\x29\x04\x17\x01\x02\x00\x00\x00\x00\x00\x00\xF4\x3F\x00", 16,
+                "[0] (fir,fin) SELECT {g41v4 qc=17 #2:1.2}");
+    check_parse(dnp3_p_app_response, "\xC0\x81\x00\x00\x29\x04\x17\x01\x02\x00\x00\x00\x00\x00\x00\xF4\x3F\x00", 18,
+                "[0] (fir,fin) RESPONSE {g41v4 qc=17 #2:1.2}");
+
+}
+
 static void test_req_operate(void)
 {
     // examples given in IEEE 1815-2012 (subclause 4.4.4.4)
@@ -1220,6 +1237,7 @@ int main(int argc, char *argv[])
     g_test_add_func("/app/req/read", test_req_read);
     g_test_add_func("/app/req/write", test_req_write);
     g_test_add_func("/app/req/select", test_req_select);
+    g_test_add_func("/app/req/select_float", test_req_select_float);
     g_test_add_func("/app/req/operate", test_req_operate);
     g_test_add_func("/app/req/direct_operate", test_req_direct_operate);
     g_test_add_func("/app/req/direct_operate_nr", test_req_direct_operate_nr);


### PR DESCRIPTION
This enables building with code coverage support.

```
cmake .. -DCOVERAGE=ON
./dnp3-tests
lcov -c -d ./ -b ./ -o coverage.info
genhtml coverage.info -o test_html
```

Could probably take this a step further and add a custom target, but this will do for now.
