### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ Sven M. Hallberg, 2014-2015
        cmake ..
        make
 
- * Run './test' to execute the unit tests (uses the GLib test framework).
+ * Run './dnp3-tests' to execute the unit tests (uses the GLib test framework).
 
  * The './dissect' utility is an example application that accepts DNP3 traffic
    (as a stream of raw link-layer frames) on stdin and prints it in human-


### PR DESCRIPTION
It looks like the test suite executable has been `dnp3-tests` since the build system was upgraded to CMake @ commit 60172eb989e3f9734bb6747b140030b83f0cdf4c.
